### PR TITLE
Import Aer from qiskit_aer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest==6.2.4
 qiskit
+qiskit-aer

--- a/src/random.py
+++ b/src/random.py
@@ -1,5 +1,6 @@
 """Docstring."""
-from qiskit import Aer, QuantumCircuit, execute, QuantumRegister, ClassicalRegister
+from qiskit import QuantumCircuit, execute, QuantumRegister, ClassicalRegister
+from qiskit_aer import Aer
 
 
 class Random:


### PR DESCRIPTION
As of Qiskit 0.44.0 (2023-07-27), Aer is removed from qiskit and part of the qiskit-aer package.